### PR TITLE
Fix paths for GitHub Pages

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,0 +1,11 @@
+/* Base styles for dark theme */
+body {
+  background-color: #111827; /* gray-900 */
+  color: #ffffff;
+}
+
+/* Ensure map container scales well */
+.map-container svg {
+  max-width: 100%;
+  height: auto;
+}

--- a/index.html
+++ b/index.html
@@ -29,10 +29,10 @@
   }
 }
 </script>
-<link rel="stylesheet" href="/index.css">
+<link rel="stylesheet" href="./index.css">
 </head>
 <body class="bg-gray-900 text-white">
   <div id="root"></div>
-  <script type="module" src="/index.jsx"></script>
+  <script type="module" src="./index.jsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix asset paths so the scripts load on GitHub Pages
- add basic dark-mode CSS to avoid missing file

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595834152c8324947b18bc73af94cd