### PR TITLE
Fix JSX loading on GitHub Pages

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, createContext } from 'react';
 import { Language } from './types.js';
 import { INITIAL_XP, INITIAL_LEVEL, COUNTRIES, TRANSLATIONS, getTranslation } from './gameData.js';
-import { SetupScreen, GameScreen, LanguageSwitcher } from './components';
+import { SetupScreen, GameScreen, LanguageSwitcher } from './components.jsx';
 
 const initialPlayerState = {
   character: null,

--- a/components.jsx
+++ b/components.jsx
@@ -2,7 +2,7 @@
 import React, { useState, useContext, useEffect, useRef } from 'react';
 import { Language } from './types.js';
 import { AVAILABLE_CHARACTERS, COUNTRIES, PREDEFINED_MESSAGES, getTranslation, TRANSLATIONS, XP_PER_LEVEL } from './gameData.js';
-import { GameContext, LanguageContext } from './App'; // Assuming contexts are exported from App.tsx
+import { GameContext, LanguageContext } from './App.jsx';
 import * as d3 from 'd3';
 import *লাইনেtopojson from 'topojson-client';
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://d3js.org/d3.v7.min.js"></script>
   <script src="https://d3js.org/topojson.v3.min.js"></script>
+  <!-- Babel compiler for JSX support on GitHub Pages -->
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <style>
     body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; }
     .map-container svg { display: block; margin: auto; }
@@ -33,6 +35,6 @@
 </head>
 <body class="bg-gray-900 text-white">
   <div id="root"></div>
-  <script type="module" src="./index.jsx"></script>
+  <script type="text/babel" data-type="module" data-presets="env,react" src="./index.jsx"></script>
 </body>
 </html>

--- a/index.jsx
+++ b/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App'; // Updated import
+import App from './App.jsx';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {


### PR DESCRIPTION
## Summary
- use Babel Standalone to transpile JSX when serving files directly on GitHub Pages
- adjust module imports to include `.jsx` extensions so the browser can locate files

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68595a99c7008324b7ec9c8a5bee7af3