### PR TITLE
Fix runtime Babel imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <script src="https://d3js.org/topojson.v3.min.js"></script>
   <!-- Babel compiler for JSX support on GitHub Pages -->
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='8' fill='%2300aaff'/%3E%3Ctext x='8' y='12' text-anchor='middle' font-size='10' fill='white'%3EDB%3C/text%3E%3C/svg%3E"/>
   <style>
     body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; }
     .map-container svg { display: block; margin: auto; }
@@ -35,6 +36,8 @@
 </head>
 <body class="bg-gray-900 text-white">
   <div id="root"></div>
+  <script type="text/babel" data-type="module" data-presets="env,react" src="./components.jsx"></script>
+  <script type="text/babel" data-type="module" data-presets="env,react" src="./App.jsx"></script>
   <script type="text/babel" data-type="module" data-presets="env,react" src="./index.jsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add inline favicon to avoid 404
- compile `App.jsx` and `components.jsx` in the browser

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685971334ee083248f55c028cf64dbde